### PR TITLE
Sign correction for postOnly key

### DIFF
--- a/bpx/bpx.py
+++ b/bpx/bpx.py
@@ -75,6 +75,9 @@ class BpxClient:
 
     def sign(self, instruction: str, params: dict):
         sign_str = f"instruction={instruction}" if instruction else ""
+        if 'postOnly' in params:
+            params = params.copy()
+            params['postOnly'] = str(params['postOnly']).lower()
         sorted_params = "&".join(
             f"{key}={value}" for key, value in sorted(params.items())
         )


### PR DESCRIPTION
To sign orderExecute with the postOnly key, the value of the postOnly key must be written in lowercase letters.